### PR TITLE
fix: explicitly use absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 hey hey!
 
-I am `lrlna`, a Rust engineer working on a graphql compiler [@apollographql](github.com/apollographql). You can find me online on <a rel="me" href="https://toot.cafe/@lrlna">Mastodon</a>. I also make zines, most of which I upload to [smol-zines](github.com/lrlna/smol-zines) repo here.
+I am `lrlna`, a Rust engineer working on a graphql compiler [@apollographql](https://github.com/apollographql). You can find me online on <a rel="me" href="https://toot.cafe/@lrlna">Mastodon</a>. I also make zines, most of which I upload to [smol-zines](https://github.com/lrlna/smol-zines) repo here.


### PR DESCRIPTION
Without this GitHub resolved them as relative URLs which wouldn't work.